### PR TITLE
docs: simplify scope (remove tasks 11, 13, 15, 16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,5 +49,8 @@ Do not push directly to `main`. Ensure all configuration and documentation chang
 - When all tasks currently listed in `tasks.md` are complete, bump the minor version.
 - Reserve additional patch versions for hotfixes unrelated to task completion.
 
+## Scope Note
+- Resource endpoints (`list_resources`, `read_resource`) are currently out of scope. Focus on tool catalog exposure (`list_tools`) and tool correctness.
+
 ## Security & Configuration Tips
 Respect directory allow-lists when accessing workbooks; never bypass via manual path joins. Keep operations bounded (≤10k cells, ≤128KB payload) and surface new limits through metadata. Document environment or config additions in `config/` and `design.md`. Use existing logging and middleware hooks instead of ad-hoc prints for telemetry or audits.

--- a/requirements.md
+++ b/requirements.md
@@ -174,13 +174,12 @@ The MCP Excel Analysis Server is a Model Context Protocol (MCP) compliant servic
 
 ### Requirement 16
 
-**User Story:** As an MCP client developer, I want the server to describe its tools and resources with protocol-compliant schemas, so that I can integrate reliably without reverse engineering behaviors.
+**User Story:** As an MCP client developer, I want the server to describe its tools with protocol-compliant schemas, so that I can integrate reliably without reverse engineering behaviors.
 
 #### Acceptance Criteria
 
 1. WHEN an MCP client calls `list_tools` THEN the server SHALL enumerate each tool (open, read, search, filter, write, transform, insights, metadata-only) with JSON schema definitions covering input parameters, default limits, and response structures
-2. WHEN an MCP client calls `list_resources` or retrieves a resource THEN the server SHALL expose workbook metadata, previews, and configuration references via registered resource URIs with declared MIME types and size bounds
-3. WHEN tool invocations return errors THEN the server SHALL use MCP structured error payloads (code, message, actionable `nextSteps`) consistent with the error catalog defined in this document
+2. WHEN tool invocations return errors THEN the server SHALL use MCP structured error payloads (code, message, actionable `nextSteps`) consistent with the error catalog defined in this document
 
 ### Requirement 17
 

--- a/steering/product.md
+++ b/steering/product.md
@@ -31,7 +31,7 @@ A Model Context Protocol (MCP) server built in Go that enables AI assistants to 
 - CI: GitHub Actions at `.github/workflows/ci.yml` running `make lint`, `make test`, and `make test-race` on pushes and PRs.
 - PR workflow: create a feature branch, open a PR to `main`, await green CI, squash-merge, and delete the branch.
 - Versioning: Semantic Versioning (vX.Y.Z). Tags are pushed and a GitHub Release is generated with notes.
-- Current version: v0.2.4
+- Current version: v0.2.5
 - Policy: bump the patch version for each completed task. When all tasks currently listed in `tasks.md` are complete, bump the minor version. Use extra patch bumps for hotfixes.
 - Go module: `github.com/vinodismyname/mcpxcel` (ensure imports use this path).
 - Documentation updates and config changes must be included in PRs alongside code changes.

--- a/tasks.md
+++ b/tasks.md
@@ -13,15 +13,15 @@
   - _Requirements: 15.1, 15.3_
 
 - [x] 2. Stand up MCP server bootstrap and lifecycle management
-  - Initialize `server.NewMCPServer` with `WithToolCapabilities`, `WithResourceCapabilities`, `WithRecovery`, hooks, and middleware following mark3labs/mcp-go advanced server patterns.
+  - Initialize `server.NewMCPServer` with `WithToolCapabilities`, `WithRecovery`, hooks, and middleware following mark3labs/mcp-go advanced server patterns.
   - Implement `ServeStdio` startup with graceful shutdown handler (`context.WithTimeout`, signal capture) and panic-safe logging hooks.
-  - Wire base telemetry hook invocations for session registration, tool calls, and resource reads.
-  - _Requirements: 16.1, 16.2_
+  - Wire base logging hook invocations for session registration and tool calls.
+  - _Requirements: 16.1_
 
 - [x] 3. Implement runtime limits and concurrency controller
   - Build `RuntimeLimits` struct hydrated from configuration for payload, timeout, request, and workbook caps.
   - Create `RuntimeController` wrapping `semaphore.Weighted` controls for global request concurrency and max open workbooks with context-aware acquire/release.
-  - Add middleware ensuring busy responses (`BUSY_RESOURCE`) or queue/backoff when limits are hit, emitting structured metrics counters.
+  - Add middleware ensuring busy responses (`BUSY_RESOURCE`) or queue/backoff when limits are hit.
   - _Requirements: 12.1, 12.2, 12.4, 15.1_
 
 - [x] 4. Create workbook lifecycle manager and stateless handle cache
@@ -33,14 +33,14 @@
 - [x] 5. Build filesystem security and path validation guardrails
   - Construct allow-list policy resolving absolute paths, preventing traversal, and validating extensions before open/write operations.
   - Surface permission errors with actionable codes and log audit events for accepted/denied access attempts.
-  - Add directory configuration validation on startup with fail-safe behavior and telemetry hooks.
+  - Add directory configuration validation on startup with fail-safe behavior and logging hooks.
   - _Requirements: 13.1, 13.2, 13.3, 13.4_
 
 - [x] 6. Implement MCP tool and discovery registry foundation
   - Define typed tool metadata using `mcp.NewTool` plus `mcp.NewTypedToolHandler`, including parameter schemas, defaults, and descriptions.
   - Register tool filters and middleware for permission/context awareness (e.g., admin-gated writes) leveraging server tool filtering APIs.
   - Ensure `list_tools` surfaces schemas, default limits, and capability flags consistent with protocol expectations.
-  - _Requirements: 16.1, 16.2_
+  - _Requirements: 16.1_
 
 - [x] 7. Implement workbook access and structure discovery tools
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 10.1, 10.2, 10.3, 10.4, 11.2_
@@ -139,11 +139,7 @@
     - Exclude raw data tables from responses while surfacing trends, anomalies, and recommended next queries.
     - _Requirements: 9.1, 9.2, 9.3, 9.4_
 
-- [ ] 11. Build MCP resource system for metadata and previews
-  - Register file metadata, preview snapshots, and configuration resources using stable URIs (e.g., `excel://files/{base64path}/structure`).
-  - Implement resource handlers returning declared MIME types, size bounds, and honoring allow-list validation.
-  - Surface effective configuration limits and server capabilities through `list_resources` and discovery metadata.
-  - _Requirements: 2.4, 15.2, 16.2_
+ 
 
 - [ ] 12. Establish validation, error handling, and retry semantics
   - _Requirements: 11.3, 11.4, 14.1, 14.2, 14.3, 14.4, 14.5, 16.1_
@@ -164,31 +160,17 @@
     - Convert timeout/cancellation to structured `TIMEOUT` errors with scope-narrowing recommendations.
     - _Requirements: 14.1, 14.3_
 
-- [ ] 13. Add telemetry, monitoring, and audit systems
-  - Integrate logging middleware capturing session/tool/resource events with timing and error annotations.
-  - Expose metrics for request latency, concurrency semaphore saturation, workbook cache hits, and LangChain durations.
-  - Emit audit logs for file access decisions (allowed/denied) and sensitive tool invocations with file paths (or redacted canonical path).
-  - _Requirements: 12.4, 13.4_
+ 
 
-- [ ] 14. Implement configuration management and deployment assets
+- [ ] 14. Implement configuration management
   - Load hierarchical configuration (YAML + env + CLI) with validation, default limit documentation, and effective-value exposure.
   - Provide sample config files and documentation for tuning payload, concurrency, and directory guardrails.
   - Document environment variable `MCPXCEL_ALLOWED_DIRS` (path list) in config docs and reference in design.md.
-  - Create containerization and build scripts (multi-stage Dockerfile, non-root user) aligned with deployment best practices.
   - _Requirements: 15.1, 15.2, 15.3_
 
-- [ ] 15. Build comprehensive test suite
-  - Author table-driven unit tests for each tool handler covering success, validation, concurrency, and error mapping paths.
-  - Create concurrency tests using race detector and stress harnesses to verify semaphore behavior and workbook locks.
-  - Add streaming/large-file fixtures ensuring memory bounds, pagination stability, and iterator closure semantics.
-  - Mock LangChainGo chains/LLMs to test insight fallbacks and timeout handling; include protocol integration tests for `list_tools`/`list_resources`.
-  - _Requirements: All requirements coverage verification_
+ 
 
-- [ ] 16. Add production readiness features
-  - Implement health/readiness endpoints (for HTTP transport) and CLI switches for modes (stdio vs HTTP).
-  - Enable optional TLS HTTP transport with connection limits, auth middleware, and structured access logs.
-  - Provide systemd unit, sample launch scripts, and operational runbooks covering scaling and observability hooks.
-  - _Requirements: 12.4, 15.2, 16.2_
+ 
 
 ## Per-Task GitHub Workflow
 


### PR DESCRIPTION
This PR simplifies the plan and design by removing tasks 11 (MCP resources), 13 (telemetry/metrics/audit systems), 15 (comprehensive test suite), and 16 (prod readiness features).\n\nChanges:\n- tasks.md: removed tasks 11/13/15/16; adjusted earlier tasks to drop resource & telemetry mentions; kept tool discovery (list_tools) only.\n- requirements.md: Requirement 16 now tool-catalog only; removed list_resources acceptance; renumbered accordingly.\n- design.md: removed resource system and telemetry sections; updated bootstrap, goals, and references; updated latest release to v0.2.5.\n- steering/product.md: bumped current version to v0.2.5.\n- AGENTS.md: added scope note that resource endpoints are out of scope for now.\n\nValidation: docs-only change. CI (lint/test) unaffected.\n\nVersioning: per policy, publishing a patch release after merge (v0.2.5).