### PR TITLE
docs: bump current version to v0.2.9

### DIFF
--- a/steering/product.md
+++ b/steering/product.md
@@ -32,7 +32,7 @@ A Model Context Protocol (MCP) server built in Go that enables AI assistants to 
 - CI: GitHub Actions at `.github/workflows/ci.yml` running `make lint`, `make test`, and `make test-race` on pushes and PRs.
 - PR workflow: create a feature branch, open a PR to `main`, await green CI, squash-merge, and delete the branch.
 - Versioning: Semantic Versioning (vX.Y.Z). Tags are pushed and a GitHub Release is generated with notes.
-- Current version: v0.2.8
+- Current version: v0.2.9
 - Policy: bump the patch version for each completed task. When all tasks currently listed in `tasks.md` are complete, bump the minor version. Use extra patch bumps for hotfixes.
 - Go module: `github.com/vinodismyname/mcpxcel` (ensure imports use this path).
 - Documentation updates and config changes must be included in PRs alongside code changes.


### PR DESCRIPTION
Reflects the v0.2.9 patch release (detect_tables: multi-table detection + header samples).